### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/near/omni-transaction-rs/compare/v0.1.0...v0.1.1) - 2024-12-06
+
+### Other
+
+- Update Cargo.toml
+- Update LICENSE-APACHE

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-transaction"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `omni-transaction`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/near/omni-transaction-rs/compare/v0.1.0...v0.1.1) - 2024-12-06

### Other

- Update Cargo.toml
- Update LICENSE-APACHE
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).