### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/near/omni-transaction-rs/compare/v0.2.1...v0.2.2) - 2025-06-23
+
+### Other
+
+- added clone to evm transaction ([#29](https://github.com/near/omni-transaction-rs/pull/29))
+
 ## [0.1.1](https://github.com/near/omni-transaction-rs/compare/v0.1.0...v0.1.1) - 2024-12-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-transaction"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `omni-transaction`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/near/omni-transaction-rs/compare/v0.2.1...v0.2.2) - 2025-06-23

### Other

- added clone to evm transaction ([#29](https://github.com/near/omni-transaction-rs/pull/29))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).