### PR TITLE
feat: extended actions with Delegate, DeployGlobalContract, UseGlobalContract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ near = []
 rlp = "0.6.1"
 hex = "0.4.3"
 borsh = { version = "1.0.0", features = ["derive"] }
-near-sdk = { version = "5.3.0", features = ["schemars"] }
+schemars = { version = "0.8" }
+near-sdk = { version = "5.3.0", features = ["schemars", "non-contract-usage"] }
 near-account-id = { version = "1.1.1", features = ["schemars-stable"] }
 serde-big-array = "0.5.1"
 bs58 = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
-schemars = { version = "0.8" }
 sha2 = { version = "0.10.8", optional = true }
 
 
@@ -71,6 +71,8 @@ k256 = { version = "0.13.1", features = [
     "arithmetic",
     "expose-field",
 ] }
+
+openssl = { version = "0.10.56", features = ["vendored"] }
 
 # async
 tokio = { version = "1.38", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ near = []
 rlp = "0.6.1"
 hex = "0.4.3"
 borsh = { version = "1.0.0", features = ["derive"] }
-near-sdk = { version = "5.3.0", features = ["schemars"] }
+near-sdk = { version = "5.3.0", features = ["schemars", "non-contract-usage"] }
 near-account-id = { version = "1.1.1", features = ["schemars-stable"] }
 serde-big-array = "0.5.1"
 bs58 = "0.5.1"
@@ -47,13 +47,10 @@ alloy-rlp = { version = "0.3.8", features = ["derive"] }
 alloy-primitives = { version = "0.8.3" }
 
 # near
-near-primitives = { version = "0.25.0" }
-near-crypto = { version = "0.25.0" }
-near-jsonrpc-client = { git = "https://github.com/omni-rs/near-jsonrpc-client-rs", tag = "v0.12.1" }
-near-workspaces = { version = "0.13.0", features = [
-    "experimental",
-    "unstable",
-] }
+near-primitives = { version = "0.30" }
+near-crypto = { version = "0.30" }
+near-jsonrpc-client = { git = "https://github.com/omni-rs/near-jsonrpc-client-rs", rev = "5cad70319083caf6b5e1e87636061460094718eb" }
+near-workspaces = { version = "0.20", features = ["experimental", "unstable"] }
 
 # bitcoin
 bitcoin = { version = "0.32.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ alloy-primitives = { version = "0.8.3" }
 # near
 near-primitives = { version = "0.30" }
 near-crypto = { version = "0.30" }
-near-jsonrpc-client = { git = "https://github.com/omni-rs/near-jsonrpc-client-rs", rev = "5cad70319083caf6b5e1e87636061460094718eb" }
+near-jsonrpc-client = { version = "0.17.0" }
 near-workspaces = { version = "0.20", features = ["experimental", "unstable"] }
 
 # bitcoin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ k256 = { version = "0.13.1", features = [
 
 # async
 tokio = { version = "1.38", features = ["full"] }
-openssl = { version = "0.10.56", features = ["vendored"] }
 
 # misc
 eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ near = []
 rlp = "0.6.1"
 hex = "0.4.3"
 borsh = { version = "1.0.0", features = ["derive"] }
-near-sdk = { version = "5.3.0", features = ["schemars", "non-contract-usage"] }
+near-sdk = { version = "5.15.1", features = ["schemars", "non-contract-usage"] }
 near-account-id = { version = "1.1.1", features = ["schemars-stable"] }
 serde-big-array = "0.5.1"
 bs58 = "0.5.1"
@@ -49,7 +49,7 @@ alloy-primitives = { version = "0.8.3" }
 # near
 near-primitives = { version = "0.30" }
 near-crypto = { version = "0.30" }
-near-jsonrpc-client = { version = "0.17.0" }
+near-jsonrpc-client = { version = "0.17.0", features = ["any"] }
 near-workspaces = { version = "0.20", features = ["experimental", "unstable"] }
 
 # bitcoin
@@ -71,6 +71,7 @@ k256 = { version = "0.13.1", features = [
 
 # async
 tokio = { version = "1.38", features = ["full"] }
+openssl = { version = "0.10.56", features = ["vendored"] }
 
 # misc
 eyre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ near = []
 rlp = "0.6.1"
 hex = "0.4.3"
 borsh = { version = "1.0.0", features = ["derive"] }
-schemars = { version = "0.8" }
-near-sdk = { version = "5.3.0", features = ["schemars", "non-contract-usage"] }
+near-sdk = { version = "5.3.0", features = ["schemars"] }
 near-account-id = { version = "1.1.1", features = ["schemars-stable"] }
 serde-big-array = "0.5.1"
 bs58 = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
+schemars = { version = "0.8" }
 sha2 = { version = "0.10.8", optional = true }
 
 
@@ -71,8 +71,6 @@ k256 = { version = "0.13.1", features = [
     "arithmetic",
     "expose-field",
 ] }
-
-openssl = { version = "0.10.56", features = ["vendored"] }
 
 # async
 tokio = { version = "1.38", features = ["full"] }

--- a/src/bitcoin/bitcoin_transaction.rs
+++ b/src/bitcoin/bitcoin_transaction.rs
@@ -532,7 +532,7 @@ mod tests {
             )
             .unwrap(); // Handle the Result
 
-        println!("serialized buffer {:?}", buffer);
+        println!("serialized buffer {buffer:?}");
         // Omni implementation
         let omni_tx = OmniBitcoinTransaction {
             version: Version::Two,
@@ -558,7 +558,7 @@ mod tests {
             &OmniScriptBuf::default(),
             OmniAmount::from_sat(0).to_sat(),
         );
-        println!("serialized BTC Omni: {:?}", serialized);
+        println!("serialized BTC Omni: {serialized:?}");
 
         assert_eq!(buffer.len(), serialized.len());
         assert_eq!(buffer, serialized);
@@ -595,7 +595,7 @@ mod tests {
         "#;
 
         let tx = OmniBitcoinTransaction::from_json(json).unwrap();
-        println!("tx: {:?}", tx);
+        println!("tx: {tx:?}");
     }
 
     #[test]
@@ -629,7 +629,7 @@ mod tests {
         "#;
 
         let tx = OmniBitcoinTransaction::from_json(json).unwrap();
-        println!("tx: {:?}", tx);
+        println!("tx: {tx:?}");
 
         assert_eq!(tx.version, Version::One);
         assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());
@@ -695,7 +695,7 @@ mod tests {
         "#;
 
         let tx = OmniBitcoinTransaction::from_json(json).unwrap();
-        println!("tx: {:?}", tx);
+        println!("tx: {tx:?}");
 
         assert_eq!(tx.version, Version::Two);
         assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());
@@ -761,7 +761,7 @@ mod tests {
         "#;
 
         let tx = OmniBitcoinTransaction::from_json(json).unwrap();
-        println!("tx: {:?}", tx);
+        println!("tx: {tx:?}");
 
         assert_eq!(tx.version, Version::Two);
         assert_eq!(tx.lock_time, LockTime::from_height(0).unwrap());

--- a/src/bitcoin/types/lock_time/lock_time.rs
+++ b/src/bitcoin/types/lock_time/lock_time.rs
@@ -37,7 +37,7 @@ impl LockTime {
         if Height::is_valid(height) {
             Ok(Self(height))
         } else {
-            Err(format!("Invalid block height: {}", height))
+            Err(format!("Invalid block height: {height}"))
         }
     }
 
@@ -45,7 +45,7 @@ impl LockTime {
         if Time::is_valid(time) {
             Ok(Self(time))
         } else {
-            Err(format!("Invalid timestamp: {}", time))
+            Err(format!("Invalid timestamp: {time}"))
         }
     }
 

--- a/src/bitcoin/types/tx_in/outpoint.rs
+++ b/src/bitcoin/types/tx_in/outpoint.rs
@@ -148,7 +148,7 @@ impl<'de> serde::de::Visitor<'de> for OutPointVisitor {
                     );
                 }
                 _ => {
-                    return Err(serde::de::Error::custom(format!("Unexpected key: {}", key)));
+                    return Err(serde::de::Error::custom(format!("Unexpected key: {key}")));
                 }
             }
         }
@@ -187,7 +187,7 @@ mod tests {
         }"#;
 
         let outpoint: OutPoint = serde_json::from_str(json_string).unwrap();
-        println!("outpoint = {:?}", outpoint);
+        println!("outpoint = {outpoint:?}");
         assert_eq!(
             outpoint,
             OutPoint {
@@ -210,7 +210,7 @@ mod tests {
         }"#;
 
         let outpoint: OutPoint = serde_json::from_str(json_string).unwrap();
-        println!("outpoint = {:?}", outpoint);
+        println!("outpoint = {outpoint:?}");
         assert_eq!(
             outpoint,
             OutPoint {

--- a/src/bitcoin/types/version.rs
+++ b/src/bitcoin/types/version.rs
@@ -137,7 +137,7 @@ impl fmt::Display for Version {
             Self::One => "1",
             Self::Two => "2",
         };
-        write!(f, "{}", version_number)
+        write!(f, "{version_number}")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,11 @@ mod transaction_builders;
 
 pub use transaction_builder::{TransactionBuilder, TxBuilder};
 /// Alias for BitcoinTransactionBuilder
+#[cfg(feature = "bitcoin")]
 pub use transaction_builders::BITCOIN;
 /// Alias for EVMTransactionBuilder
+#[cfg(feature = "evm")]
 pub use transaction_builders::EVM;
 /// Alias for NearTransactionBuilder
+#[cfg(feature = "near")]
 pub use transaction_builders::NEAR;

--- a/src/near/near_transaction.rs
+++ b/src/near/near_transaction.rs
@@ -105,6 +105,7 @@ mod tests {
         transaction::Transaction as NearPrimitiveTransaction,
         transaction::TransactionV0,
     };
+    use near_sdk::json_types::Base64VecU8;
 
     #[derive(Debug)]
     struct TestCase {
@@ -144,7 +145,7 @@ mod tests {
                     code: vec![0x01, 0x02, 0x03],
                 })],
                 omni_actions: vec![OmniAction::DeployContract(OmniDeployContractAction {
-                    code: vec![0x01, 0x02, 0x03],
+                    code: Base64VecU8(vec![0x01, 0x02, 0x03]),
                 })],
             },
             // Function Call
@@ -320,7 +321,7 @@ mod tests {
                 })],
                 omni_actions: vec![
                     OmniAction::DeployGlobalContract(OmniDeployGlobalContractAction {
-                        code: vec![0x01, 0x02, 0x03],
+                        code: Base64VecU8(vec![0x01, 0x02, 0x03]),
                         deploy_mode: OmniGlobalContractDeployMode::AccountId,
                     }),
                 ],

--- a/src/near/near_transaction.rs
+++ b/src/near/near_transaction.rs
@@ -72,6 +72,7 @@ impl NearTransaction {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use super::*;
     use crate::near::types::{
@@ -79,10 +80,14 @@ mod tests {
         Action as OmniAction, AddKeyAction as OmniAddKeyAction,
         CreateAccountAction as OmniCreateAccountAction, DelegateAction as OmniDelegateAction,
         DeleteAccountAction as OmniDeleteAccountAction, DeleteKeyAction as OmniDeleteKeyAction,
-        DeployContractAction as OmniDeployContractAction, ED25519Signature,
-        FunctionCallAction as OmniFunctionCallAction, Secp256K1Signature,
+        DeployContractAction as OmniDeployContractAction,
+        DeployGlobalContractAction as OmniDeployGlobalContractAction, ED25519Signature,
+        FunctionCallAction as OmniFunctionCallAction,
+        GlobalContractDeployMode as OmniGlobalContractDeployMode,
+        GlobalContractIdentifier as OmniGlobalContractIdentifier, Secp256K1Signature,
         Signature as OmniSignature, SignedDelegateAction as OmniSignedDelegateAction,
-        StakeAction as OmniStakeAction, TransferAction as OmniTransferAction, U128,
+        StakeAction as OmniStakeAction, TransferAction as OmniTransferAction,
+        UseGlobalContractAction as OmniUseGlobalContractAction, U128,
     };
     use crate::near::utils::PublicKeyStrExt;
     use near_crypto::{ED25519PublicKey, PublicKey, Signature};
@@ -90,7 +95,8 @@ mod tests {
     use near_primitives::action::delegate::{DelegateAction, SignedDelegateAction};
     use near_primitives::action::{
         CreateAccountAction, DeleteAccountAction, DeleteKeyAction, DeployContractAction,
-        FunctionCallAction, StakeAction,
+        DeployGlobalContractAction, FunctionCallAction, GlobalContractDeployMode,
+        GlobalContractIdentifier, StakeAction, UseGlobalContractAction,
     };
     use near_primitives::{
         account::{AccessKey, AccessKeyPermission},
@@ -287,21 +293,38 @@ mod tests {
                     signature: signature.clone()
                 }))],
             },
-            // TestCase {
-            //     signer_id: "alice.near",
-            //     signer_public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
-            //     nonce: 1,
-            //     receiver_id: "bob.near",
-            //     block_hash: "4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ",
-            //     near_primitive_actions: vec![Action::UseGlobalContract(Box::new(UseGlobalContractAction {
-            //         contract_identifier: GlobalContractIdentifier::CodeHash(BlockHash::from_str("4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ").unwrap()),
-            //     }))],
-            //     omni_actions: vec![
-            //         OmniAction::UseGlobalContract(Box::new(OmniUseGlobalContractAction {
-            //             contract_identifier: OmniGlobalContractIdentifier::CodeHash(BlockHash::from_str("4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ").unwrap()),
-            //         })),
-            //     ],
-            // },
+            TestCase {
+                signer_id: "alice.near",
+                signer_public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                nonce: 1,
+                receiver_id: "bob.near",
+                block_hash: "4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ",
+                near_primitive_actions: vec![Action::UseGlobalContract(Box::new(UseGlobalContractAction {
+                    contract_identifier: GlobalContractIdentifier::CodeHash(CryptoHash::from_str("4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ").unwrap()),
+                }))],
+                omni_actions: vec![
+                    OmniAction::UseGlobalContract(Box::new(OmniUseGlobalContractAction {
+                        contract_identifier: OmniGlobalContractIdentifier::CodeHash(BlockHash("4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ".to_fixed_32_bytes().unwrap())),
+                    })),
+                ],
+            },
+            TestCase {
+                signer_id: "alice.near",
+                signer_public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                nonce: 1,
+                receiver_id: "bob.near",
+                block_hash: "4reLvkAWfqk5fsqio1KLudk46cqRz9erQdaHkWZKMJDZ",
+                near_primitive_actions: vec![Action::DeployGlobalContract(DeployGlobalContractAction {
+                    code: Arc::new([0x01, 0x02, 0x03]),
+                    deploy_mode: GlobalContractDeployMode::AccountId,
+                })],
+                omni_actions: vec![
+                    OmniAction::DeployGlobalContract(OmniDeployGlobalContractAction {
+                        code: vec![0x01, 0x02, 0x03],
+                        deploy_mode: OmniGlobalContractDeployMode::AccountId,
+                    }),
+                ],
+            },
             // Transfer and Add Key
             TestCase {
                 signer_id: "forgetful-parent.testnet",

--- a/src/near/near_transaction.rs
+++ b/src/near/near_transaction.rs
@@ -76,11 +76,11 @@ mod tests {
 
     use super::*;
     use crate::near::types::{
-        AccessKey as OmniAccessKey, AccessKeyPermission as OmniAccessKeyPermission,
-        Action as OmniAction, AddKeyAction as OmniAddKeyAction,
-        CreateAccountAction as OmniCreateAccountAction, DelegateAction as OmniDelegateAction,
-        DeleteAccountAction as OmniDeleteAccountAction, DeleteKeyAction as OmniDeleteKeyAction,
-        DeployContractAction as OmniDeployContractAction,
+        vector::Base64VecU8, AccessKey as OmniAccessKey,
+        AccessKeyPermission as OmniAccessKeyPermission, Action as OmniAction,
+        AddKeyAction as OmniAddKeyAction, CreateAccountAction as OmniCreateAccountAction,
+        DelegateAction as OmniDelegateAction, DeleteAccountAction as OmniDeleteAccountAction,
+        DeleteKeyAction as OmniDeleteKeyAction, DeployContractAction as OmniDeployContractAction,
         DeployGlobalContractAction as OmniDeployGlobalContractAction, ED25519Signature,
         FunctionCallAction as OmniFunctionCallAction,
         GlobalContractDeployMode as OmniGlobalContractDeployMode,
@@ -105,7 +105,6 @@ mod tests {
         transaction::Transaction as NearPrimitiveTransaction,
         transaction::TransactionV0,
     };
-    use near_sdk::json_types::Base64VecU8;
 
     #[derive(Debug)]
     struct TestCase {

--- a/src/near/near_transaction.rs
+++ b/src/near/near_transaction.rs
@@ -294,6 +294,7 @@ mod tests {
                     signature
                 }))],
             },
+            // Use Global Contract
             TestCase {
                 signer_id: "alice.near",
                 signer_public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
@@ -309,6 +310,7 @@ mod tests {
                     })),
                 ],
             },
+            // Deploy Global Contract
             TestCase {
                 signer_id: "alice.near",
                 signer_public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",

--- a/src/near/near_transaction.rs
+++ b/src/near/near_transaction.rs
@@ -290,7 +290,7 @@ mod tests {
                         max_block_height: U64(1),
                         public_key: "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp".to_public_key().unwrap(),
                     },
-                    signature: signature.clone()
+                    signature
                 }))],
             },
             TestCase {
@@ -401,8 +401,7 @@ mod tests {
 
             assert_eq!(
                 serialized_near_primitive_v0_tx, serialized_omni_tx,
-                "Test case {} failed: serialized transactions do not match.\nNEAR: {:?}\nOmni: {:?}",
-                i, serialized_near_primitive_v0_tx, serialized_omni_tx
+                "Test case {i} failed: serialized transactions do not match.\nNEAR: {serialized_near_primitive_v0_tx:?}\nOmni: {serialized_omni_tx:?}"
             );
         }
     }
@@ -464,8 +463,7 @@ mod tests {
 
             assert_eq!(
                 serialized_omni_tx, encoded_signed_tx,
-                "Test case {} failed: serialized transactions do not match.\nNEAR: {:?}\nOmni: {:?}",
-                i, serialized_omni_tx, encoded_signed_tx
+                "Test case {i} failed: serialized transactions do not match.\nNEAR: {serialized_omni_tx:?}\nOmni: {encoded_signed_tx:?}"
             );
         }
     }
@@ -538,8 +536,7 @@ mod tests {
 
             assert_eq!(
                 serialized_omni_tx, encoded_signed_tx,
-                "Test case {} failed: serialized transactions do not match.\nNEAR: {:?}\nOmni: {:?}",
-                i, serialized_omni_tx, encoded_signed_tx
+                "Test case {i} failed: serialized transactions do not match.\nNEAR: {serialized_omni_tx:?}\nOmni: {encoded_signed_tx:?}"
             );
         }
     }

--- a/src/near/types/actions.rs
+++ b/src/near/types/actions.rs
@@ -420,8 +420,7 @@ mod tests {
 
             assert_eq!(
                     action, deserialized,
-                    "Serialization/Deserialization mismatch: original action: {:?}, deserialized action: {:?}",
-                    action, deserialized
+                    "Serialization/Deserialization mismatch: original action: {action:?}, deserialized action: {deserialized:?}"
                 );
         }
     }
@@ -438,8 +437,7 @@ mod tests {
 
             assert_eq!(
                 action, deserialized,
-                "Serialization/Deserialization mismatch: original action: {:?}, deserialized action: {:?}",
-                action, deserialized
+                "Serialization/Deserialization mismatch: original action: {action:?}, deserialized action: {deserialized:?}"
             );
         }
     }

--- a/src/near/types/actions.rs
+++ b/src/near/types/actions.rs
@@ -1,6 +1,5 @@
-use crate::near::types::{BlockHash, PublicKey, Signature};
+use crate::near::types::{vector::Base64VecU8, BlockHash, PublicKey, Signature};
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 use schemars::JsonSchema;

--- a/src/near/types/actions.rs
+++ b/src/near/types/actions.rs
@@ -1,5 +1,6 @@
 use crate::near::types::{BlockHash, PublicKey, Signature};
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_sdk::json_types::Base64VecU8;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
 use schemars::JsonSchema;
@@ -49,7 +50,7 @@ pub enum Action {
 )]
 #[serde(crate = "near_sdk::serde")]
 pub struct DeployGlobalContractAction {
-    pub code: Vec<u8>,
+    pub code: Base64VecU8,
     pub deploy_mode: GlobalContractDeployMode,
 }
 
@@ -136,7 +137,7 @@ pub struct CreateAccountAction {}
 )]
 #[serde(crate = "near_sdk::serde")]
 pub struct DeployContractAction {
-    pub code: Vec<u8>,
+    pub code: Base64VecU8,
 }
 
 #[derive(
@@ -376,7 +377,7 @@ mod tests {
         vec![
             Action::CreateAccount(CreateAccountAction {}),
             Action::DeployContract(DeployContractAction {
-                code: vec![1, 2, 3],
+                code: Base64VecU8(vec![1, 2, 3]),
             }),
             Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: "test".to_string(),
@@ -404,6 +405,13 @@ mod tests {
             Action::DeleteAccount(DeleteAccountAction {
                 beneficiary_id: "alice.near".parse().unwrap(),
             }),
+            Action::DeployGlobalContract(DeployGlobalContractAction {
+                code: Base64VecU8(vec![3, 4, 5]),
+                deploy_mode: GlobalContractDeployMode::CodeHash,
+            }),
+            Action::UseGlobalContract(Box::new(UseGlobalContractAction {
+                contract_identifier: GlobalContractIdentifier::CodeHash(BlockHash([4; 32])),
+            })),
         ]
     }
 

--- a/src/near/types/actions.rs
+++ b/src/near/types/actions.rs
@@ -1,4 +1,4 @@
-use crate::near::types::PublicKey;
+use crate::near::types::{BlockHash, PublicKey, Signature};
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::AccountId;
@@ -31,6 +31,82 @@ pub enum Action {
     AddKey(Box<AddKeyAction>),
     DeleteKey(Box<DeleteKeyAction>),
     DeleteAccount(DeleteAccountAction),
+    Delegate(Box<SignedDelegateAction>),
+    DeployGlobalContract(DeployGlobalContractAction),
+    UseGlobalContract(Box<UseGlobalContractAction>),
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub struct DeployGlobalContractAction {
+    pub code: Vec<u8>,
+    pub deploy_mode: GlobalContractDeployMode,
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub struct UseGlobalContractAction {
+    pub contract_identifier: GlobalContractIdentifier,
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub enum GlobalContractDeployMode {
+    /// Contract is deployed under its code hash.
+    /// Users will be able reference it by that hash.
+    /// This effectively makes the contract immutable.
+    CodeHash,
+    /// Contract is deployed under the owner account id.
+    /// Users will be able reference it by that account id.
+    /// This allows the owner to update the contract for all its users.
+    AccountId,
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub enum GlobalContractIdentifier {
+    CodeHash(BlockHash),
+    AccountId(AccountId),
 }
 
 #[derive(
@@ -225,6 +301,68 @@ pub struct DeleteKeyAction {
 #[serde(crate = "near_sdk::serde")]
 pub struct DeleteAccountAction {
     pub beneficiary_id: AccountId,
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub struct NonDelegateAction(Action);
+
+impl TryFrom<Action> for NonDelegateAction {
+    type Error = ();
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        if let Action::Delegate(_) = action {
+            return Err(());
+        }
+        Ok(Self(action))
+    }
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub struct DelegateAction {
+    pub sender_id: AccountId,
+    pub receiver_id: AccountId,
+    pub actions: Vec<NonDelegateAction>,
+    pub nonce: U64,
+    pub max_block_height: U64,
+    pub public_key: PublicKey,
+}
+
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    BorshSerialize,
+    BorshDeserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+)]
+#[serde(crate = "near_sdk::serde")]
+pub struct SignedDelegateAction {
+    pub delegate_action: DelegateAction,
+    pub signature: Signature,
 }
 
 #[cfg(test)]

--- a/src/near/types/block_hash.rs
+++ b/src/near/types/block_hash.rs
@@ -89,7 +89,7 @@ mod tests {
         let base58 = "CjNSmWXTWhC3EhRVtqLhRmWMTkRbU96wUACqxMtV1uGf";
 
         // Serialize to JSON string
-        let json = format!("\"{}\"", base58);
+        let json = format!("\"{base58}\"");
 
         // Deserialize from JSON string using serde_json
         let block_hash: BlockHash = serde_json::from_str(&json).unwrap();

--- a/src/near/types/integers.rs
+++ b/src/near/types/integers.rs
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn test_u64_deserde() {
         let u64_value = 1234567890;
-        let u64_value_str = format!("\"{}\"", u64_value);
+        let u64_value_str = format!("\"{u64_value}\"");
         let deserialized: U64 = serde_json::from_str(&u64_value_str).unwrap();
 
         assert_eq!(deserialized.0, u64_value);
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     fn test_u128_deserde() {
         let u128_value = 12345678901234567890;
-        let u128_value_str = format!("\"{}\"", u128_value);
+        let u128_value_str = format!("\"{u128_value}\"");
         let deserialized: U128 = serde_json::from_str(&u128_value_str).unwrap();
 
         assert_eq!(deserialized.0, u128_value);

--- a/src/near/types/mod.rs
+++ b/src/near/types/mod.rs
@@ -4,6 +4,7 @@ mod block_hash;
 pub mod integers;
 mod public_key;
 mod signature;
+pub mod vector;
 
 pub use actions::*;
 pub use block_hash::*;

--- a/src/near/types/public_key.rs
+++ b/src/near/types/public_key.rs
@@ -181,10 +181,7 @@ impl<'de> Deserialize<'de> for Secp256K1PublicKey {
             type Value = Secp256K1PublicKey;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str(&format!(
-                    "an array of {} bytes",
-                    SECP256K1_PUBLIC_KEY_LENGTH
-                ))
+                formatter.write_str(&format!("an array of {SECP256K1_PUBLIC_KEY_LENGTH} bytes"))
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/src/near/types/signature.rs
+++ b/src/near/types/signature.rs
@@ -1,17 +1,19 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use bs58;
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Debug;
 
 use crate::constants::{COMPONENT_SIZE, SECP256K1_SIGNATURE_LENGTH};
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq, JsonSchema)]
+#[serde(crate = "near_sdk::serde")]
 pub enum Signature {
     ED25519(ED25519Signature),
     SECP256K1(Secp256K1Signature),
 }
 
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq, JsonSchema)]
 pub struct ED25519Signature {
     pub r: ComponentBytes,
     pub s: ComponentBytes,
@@ -22,6 +24,16 @@ pub type ComponentBytes = [u8; COMPONENT_SIZE];
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct Secp256K1Signature(pub [u8; SECP256K1_SIGNATURE_LENGTH]);
+
+impl JsonSchema for Secp256K1Signature {
+    fn schema_name() -> String {
+        "Secp256K1Signature".to_owned()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String>::json_schema(gen)
+    }
+}
 
 impl Serialize for Signature {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/near/types/signature.rs
+++ b/src/near/types/signature.rs
@@ -47,11 +47,11 @@ impl Serialize for Signature {
                 bytes.extend_from_slice(&sig.s);
 
                 let encoded = bs58::encode(&bytes).into_string();
-                serializer.serialize_str(&format!("ed25519:{}", encoded))
+                serializer.serialize_str(&format!("ed25519:{encoded}"))
             }
             Self::SECP256K1(sig) => {
                 let encoded = bs58::encode(&sig.0).into_string();
-                serializer.serialize_str(&format!("secp256k1:{}", encoded))
+                serializer.serialize_str(&format!("secp256k1:{encoded}"))
             }
         }
     }

--- a/src/near/types/vector.rs
+++ b/src/near/types/vector.rs
@@ -1,0 +1,72 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// TODO: we should remove that in favor of near-sdk::json_types::Base64VecU8
+// And I'm not sure if we need to put serde by default. We should follow near-sdk path with a schema only for abi
+
+/// Helper class to serialize/deserialize `Vec<u8>` to base64 string.
+///
+/// # Example
+/// ```rust
+/// use near_sdk::{json_types::Base64VecU8, near};
+///
+/// #[near(serializers=[json])]
+/// struct NewStruct {
+///     field: Base64VecU8,
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+pub struct Base64VecU8(
+    #[serde(
+        serialize_with = "base64_bytes::serialize",
+        deserialize_with = "base64_bytes::deserialize"
+    )]
+    pub Vec<u8>,
+);
+
+impl From<Vec<u8>> for Base64VecU8 {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl From<Base64VecU8> for Vec<u8> {
+    fn from(v: Base64VecU8) -> Vec<u8> {
+        v.0
+    }
+}
+
+impl JsonSchema for Base64VecU8 {
+    fn schema_name() -> String {
+        "Base64VecU8".to_string()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <String>::json_schema(gen)
+    }
+}
+
+/// Convenience module to allow annotating a serde structure as base64 bytes.
+mod base64_bytes {
+    use super::*;
+    use near_sdk::base64::Engine;
+    use serde::{de, Deserializer, Serializer};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&near_sdk::base64::engine::general_purpose::STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        near_sdk::base64::engine::general_purpose::STANDARD
+            .decode(s.as_str())
+            .map_err(de::Error::custom)
+    }
+}

--- a/src/near/types/vector.rs
+++ b/src/near/types/vector.rs
@@ -32,7 +32,7 @@ impl From<Vec<u8>> for Base64VecU8 {
 }
 
 impl From<Base64VecU8> for Vec<u8> {
-    fn from(v: Base64VecU8) -> Vec<u8> {
+    fn from(v: Base64VecU8) -> Self {
         v.0
     }
 }

--- a/src/near/utils/public_key_utils.rs
+++ b/src/near/utils/public_key_utils.rs
@@ -63,7 +63,7 @@ impl PublicKeyStrExt for str {
 
         let bytes = bs58::decode(key_data)
             .into_vec()
-            .map_err(|e| format!("Failed to decode base58: {}", e))?;
+            .map_err(|e| format!("Failed to decode base58: {e}"))?;
 
         match key_type {
             "ed25519" => {
@@ -90,7 +90,7 @@ impl PublicKeyStrExt for str {
             .and_then(|rest| {
                 let bytes = bs58::decode(rest)
                     .into_vec()
-                    .map_err(|e| format!("Failed to decode base58: {}", e))?;
+                    .map_err(|e| format!("Failed to decode base58: {e}"))?;
 
                 bytes
                     .try_into()
@@ -104,7 +104,7 @@ impl PublicKeyStrExt for str {
             .and_then(|rest| {
                 let bytes = bs58::decode(rest)
                     .into_vec()
-                    .map_err(|e| format!("Failed to decode base58: {}", e))?;
+                    .map_err(|e| format!("Failed to decode base58: {e}"))?;
 
                 bytes
                     .try_into()
@@ -121,12 +121,8 @@ impl PublicKeyStrExt for str {
 fn decode_base58_to_fixed_bytes<const N: usize>(input: &str) -> Result<[u8; N], String> {
     bs58::decode(input)
         .into_vec()
-        .map_err(|e| format!("Failed to decode base58: {}", e))
-        .and_then(|bytes| {
-            bytes
-                .try_into()
-                .map_err(|_| format!("Expected {} bytes", N))
-        })
+        .map_err(|e| format!("Failed to decode base58: {e}"))
+        .and_then(|bytes| bytes.try_into().map_err(|_| format!("Expected {N} bytes")))
 }
 
 #[cfg(test)]

--- a/src/near/utils/signature_utils.rs
+++ b/src/near/utils/signature_utils.rs
@@ -44,7 +44,7 @@ impl SignatureStrExt for str {
 
         let bytes = bs58::decode(key_data)
             .into_vec()
-            .map_err(|e| format!("Failed to decode base58: {}", e))?;
+            .map_err(|e| format!("Failed to decode base58: {e}"))?;
 
         match key_type {
             "ed25519" => {

--- a/tests/bitcoin_integration_test.rs
+++ b/tests/bitcoin_integration_test.rs
@@ -466,7 +466,7 @@ async fn test_send_p2pkh_using_rust_bitcoin_and_omni_library() -> Result<()> {
         .call("sendrawtransaction", &[json!(hex_omni_tx)])
         .unwrap();
 
-    println!("raw_tx_result: {:?}", raw_tx_result);
+    println!("raw_tx_result: {raw_tx_result:?}");
 
     client.generate_to_address(101, &bob.address)?;
 
@@ -663,7 +663,7 @@ async fn test_p2wpkh_single_utxo() -> Result<()> {
         )
         .unwrap();
 
-    println!("raw_tx_result: {:?}", raw_tx_result);
+    println!("raw_tx_result: {raw_tx_result:?}");
 
     client.generate_to_address(101, &bob.address)?;
 
@@ -891,7 +891,7 @@ async fn test_p2wpkh_multiple_utxos() -> Result<()> {
         )
         .unwrap();
 
-    println!("raw_tx_result: {:?}", raw_tx_result);
+    println!("raw_tx_result: {raw_tx_result:?}");
 
     client.generate_to_address(101, &bob.address)?;
 

--- a/tests/evm_integration_test.rs
+++ b/tests/evm_integration_test.rs
@@ -80,8 +80,8 @@ async fn test_send_raw_transaction_created_with_omnitransactionbuilder_for_evm()
         .send_raw_transaction(&omni_evm_tx_encoded_with_signature)
         .await
     {
-        Ok(tx_hash) => println!("Transaction sent successfully. Hash: {:?}", tx_hash),
-        Err(e) => println!("Failed to send transaction: {:?}", e),
+        Ok(tx_hash) => println!("Transaction sent successfully. Hash: {tx_hash:?}"),
+        Err(e) => println!("Failed to send transaction: {e:?}"),
     }
 
     eyre::Ok(())

--- a/tests/near_integration_test.rs
+++ b/tests/near_integration_test.rs
@@ -3,6 +3,8 @@ use near_crypto::InMemorySigner;
 use near_jsonrpc_client::methods::tx::{RpcTransactionError, TransactionInfo};
 use near_jsonrpc_client::{methods, JsonRpcClient};
 use near_primitives::hash::CryptoHash;
+use near_sdk::base64::prelude::BASE64_STANDARD;
+use near_sdk::base64::Engine;
 use near_workspaces::sandbox;
 use omni_transaction::near::types::{
     Action, ED25519Signature, Signature as OmniSignature, TransferAction,
@@ -90,10 +92,13 @@ async fn test_send_raw_transaction_created_with_omnitransactionbuilder_for_near(
     // Build the signed transaction
     let near_tx_signed = near_tx.build_with_signature(omni_signature);
 
-    let request = methods::send_tx::RpcSendTransactionRequest {
-        signed_transaction: serde_json::from_slice(&near_tx_signed).unwrap(),
-        wait_until: near_primitives::views::TxExecutionStatus::IncludedFinal,
-    };
+    let request = methods::any::<methods::send_tx::RpcSendTransactionRequest>(
+        "send_tx",
+        serde_json::json!({
+            "signed_tx_base64": BASE64_STANDARD.encode(&near_tx_signed),
+            "wait_until": near_primitives::views::TxExecutionStatus::IncludedFinal,
+        }),
+    );
 
     // Send the transaction
     let sent_at = time::Instant::now();

--- a/tests/near_integration_test.rs
+++ b/tests/near_integration_test.rs
@@ -90,8 +90,8 @@ async fn test_send_raw_transaction_created_with_omnitransactionbuilder_for_near(
     // Build the signed transaction
     let near_tx_signed = near_tx.build_with_signature(omni_signature);
 
-    let request = methods::send_raw_tx::RpcSendRawTransactionRequest {
-        raw_signed_transaction: near_tx_signed.clone(),
+    let request = methods::send_tx::RpcSendTransactionRequest {
+        signed_transaction: serde_json::from_slice(&near_tx_signed).unwrap(),
         wait_until: near_primitives::views::TxExecutionStatus::IncludedFinal,
     };
 


### PR DESCRIPTION
Resolves: #24 

This PR:
* Updates near-* testing deps to 0.30 release
* Adds `UseGlobalContract`, `DeployGlobalContract` actions
* Fixes compilation with no_default_features
* clippy

Just so you know, this PR introduces duplication of near-* near-25 version and near-30 version. This is happening as omni-testing-utils keeps using old near-jsonrpc-client, but it is already an archived repo.

This doesn't result in any compilation problems, but will extend building time for tests.