### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/near/omni-transaction-rs/compare/v0.2.2...v0.2.3) - 2025-07-19
+
+### Added
+
+- extended actions with Delegate, DeployGlobalContract, UseGlobalContract ([#31](https://github.com/near/omni-transaction-rs/pull/31))
+
 ## [0.2.2](https://github.com/near/omni-transaction-rs/compare/v0.2.1...v0.2.2) - 2025-06-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omni-transaction"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Proximity Labs Limited"]
 license = "Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `omni-transaction`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/near/omni-transaction-rs/compare/v0.2.2...v0.2.3) - 2025-07-19

### Added

- extended actions with Delegate, DeployGlobalContract, UseGlobalContract ([#31](https://github.com/near/omni-transaction-rs/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).